### PR TITLE
Mock test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,7 @@ To launch the system use:
 ros2 launch solo12_bringup robot.launch.py
 ```
 
-Launch arguments:
-- `stand`: Spawn robot on stand (default true).
-- `use_rviz`: Run rviz (default true).
-
-Example:
-
-```
-ros2 launch solo12_bringup robot.launch.py stand:=true use_rviz:=false
-```
+to get more details of the availables launch arguments see [solo12_bringup](./solo12_bringup/README.md) package.
 
 ## Packages
 

--- a/solo12_bringup/README.md
+++ b/solo12_bringup/README.md
@@ -1,0 +1,53 @@
+# `solo12_bringup`
+
+This is the main package to launch all the components.
+
+## Usage: `robot.launch.py`
+
+To launch the full system is `robot.launch.py`, example:
+
+```bash
+ros2 launch solo12_bringup robot.launch.py
+```
+
+Launch arguments:
+- `use_sim`: Start Gazebo (default true), otherwise start hardware.
+- `start_rviz`: Run rviz (default true).
+- `rviz_config_file`: Custom rviz config file (default `solo12_description/rviz/solo12.rviz`)
+- `robot_name`: Robot name (default "solo12"). For now just set the gazebo entity name, but this can be used later to spawn multiples robot.
+- `stand`: Spawn robot on stand (default true).
+
+Example:
+
+```
+ros2 launch solo12_bringup robot.launch.py stand:=true use_rviz:=false
+```
+
+## `state_publisher.launch.py`
+
+This launch file is the **main and only** source for the robot_description. If you want to make use of the `robot_description`, please subscribe to the topic `/robot_description`.
+
+Launch arguments:
+- `use_sim_time`: Sync ros and gazebo time (default true)
+
+## `controllers.launch.py`
+
+Launch all the components related with `ros2_control`.
+
+Launch arguments:
+- `use_sim_time`: Sync ros and gazebo time (default true)
+
+## `sim_gazebo.launch.py`
+
+Start the gazebo simulation environment. Spawn the robot and the stand.
+
+Launch arguments:
+- `stand`: spawn stand model into gazebo (default true).
+- `robot_name`: robot entity name in gazebo (default "solo12")
+
+## `start_rviz.launch.py`
+
+Start rviz.
+
+Launch arguments:
+- `rviz_config_file`: Custom cofiguration file to start rviz (no default value)

--- a/solo12_bringup/launch/controllers.launch.py
+++ b/solo12_bringup/launch/controllers.launch.py
@@ -1,0 +1,62 @@
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction, DeclareLaunchArgument
+from launch.substitutions import PathJoinSubstitution, LaunchConfiguration
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.actions import Node
+
+def launch_args(context):
+
+    declared_args = []
+
+    declared_args.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="true"
+        )
+    )
+
+    return declared_args
+
+
+def launch_setup(context):
+
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare("solo12_description"),
+            "config",
+            "solo12_controllers.yaml"
+        ]
+    )
+
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[
+            robot_controllers
+        ],
+        output="both",
+        emulate_tty=True
+    )
+
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        parameters=[{"use_sim_time": LaunchConfiguration("use_sim_time")}]
+    )
+
+    return [
+        ros2_control_node,
+        joint_state_broadcaster_spawner
+    ]
+
+
+def generate_launch_description():
+
+    ld = LaunchDescription()
+
+    ld.add_action(OpaqueFunction(function=launch_args))
+
+    ld.add_action(OpaqueFunction(function=launch_setup))
+
+    return ld

--- a/solo12_bringup/launch/robot.launch.py
+++ b/solo12_bringup/launch/robot.launch.py
@@ -1,176 +1,130 @@
-import os
-import xacro
-from launch.event_handlers import OnProcessExit
-from launch.launch_context import LaunchContext
 from launch import LaunchDescription
+from launch.actions import OpaqueFunction, DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import IfCondition
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription, RegisterEventHandler
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
+from launch.substitutions import PathJoinSubstitution, LaunchConfiguration
 from launch_ros.substitutions import FindPackageShare
-from ament_index_python.packages import get_package_share_directory
 
-def generate_launch_description():
+def launch_args(context):
 
-    declared_arguments = []
+    declared_args = []
 
-    declared_arguments.append(
+    declared_args.append(
         DeclareLaunchArgument(
-            "use_rviz",
+            "use_sim",
             default_value="true",
-            description="Start RViz2 automatically with this launch file.")
+            description="Start robot in simulation, otherwise launch for physical hardware."
+        )
     )
 
-    declared_arguments.append(
+    declared_args.append(
+        DeclareLaunchArgument(
+            "start_rviz",
+            default_value="true",
+            description="Start RViz2 automatically with this launch file."
+        )
+    )
+
+    declared_args.append(
+        DeclareLaunchArgument(
+            "rviz_config_file",
+            default_value=PathJoinSubstitution(
+                [
+                    FindPackageShare("solo12_description"),
+                    "rviz",
+                    "solo12.rviz"
+                ]
+            ),
+            description="Cofiguration file for rviz"
+        )
+    )
+
+    declared_args.append(
+        DeclareLaunchArgument(
+            "robot_name",
+            default_value="solo12",
+            description="Robot name."
+        )
+    )
+
+    declared_args.append(
         DeclareLaunchArgument(
             "stand",
             default_value="true",
-            description="Spawn stand for the robot."
+            description="Spawn the robot in a stand."
         )
     )
 
-    use_rviz = LaunchConfiguration("use_rviz")
-    stand_arg = LaunchConfiguration("stand")
+    return declared_args
 
-    rviz_config_file = PathJoinSubstitution(
-        [
-            FindPackageShare("solo12_description"),
-            "rviz",
-            "solo12.rviz"
-        ]
-    )
+def launch_setup(context):
 
-    robot_controllers = PathJoinSubstitution(
-        [
-            FindPackageShare("solo12_description"),
-            "config",
-            "solo12_controllers.yaml"
-        ]
-    )
-
-    # Get URDF path
-    urdf_path = os.path.join(
-        get_package_share_directory("solo12_description"),
-        'urdf',
-        'solo12.urdf.xacro'
-    )
-
-    # Spawn stand as a different entity.
-    #
-    # The first part of the command parse the urdf file
-    # using the `xacro` command, this is required to resolved
-    # the path of the meshes in the urdf file.
-    # The second part use the `spawn_entity.py` node with 
-    # the option `-stdin` that get the urdf from the standard
-    # input.
-    spawn_stand = ExecuteProcess(
-        cmd=[
-            "xacro",
-            PathJoinSubstitution(
-                [
-                    FindPackageShare("solo12_description"),
-                    "urdf",
-                    "stand.urdf"
-                ]
-            ),
-            "|",
-            "ros2", "run", "gazebo_ros", "spawn_entity.py", "-stdin", "-entity", "stand"
-        ],
-        output="both",
-        shell=True,
-        condition=IfCondition(stand_arg)
-    )
-
-    # robot description parameter composition
-    robot_description = {"robot_description": xacro.process_file(urdf_path).toxml()}
-
-    gazebo_configuration = PathJoinSubstitution(
-        [
-            FindPackageShare("solo12_description"),
-            "config",
-            "gazebo.yaml"
-        ]
-    )
-
-    gazebo = IncludeLaunchDescription(
+    state_publisher = IncludeLaunchDescription(
         PathJoinSubstitution(
             [
-                FindPackageShare("gazebo_ros"),
+                FindPackageShare("solo12_bringup"),
                 "launch",
-                "gazebo.launch.py"
+                "state_publisher.launch.py"
             ]
         ),
         launch_arguments={
-            # "extra_gazebo_args": f"--ros-args --params-file {gazebo_configuration.perform}" # Harley: fix path substitution
+            "use_sim_time": LaunchConfiguration("use_sim")
         }.items()
     )
 
-    spawn_entity_node = Node(
-        package="gazebo_ros",
-        executable="spawn_entity.py",
-        name="spawn_entity",
-        arguments=['-topic', "robot_description",
-                   "-x", "0.0",
-                   "-y", "0.0",
-                   "-z", "0.54", 
-                   "-entity", "solo12"]
+    sim_gazebo = IncludeLaunchDescription(
+        PathJoinSubstitution(
+            [
+                FindPackageShare("solo12_bringup"),
+                "launch",
+                "sim_gazebo.launch.py"
+            ]
+        ),
+        launch_arguments={
+            "robot_name": LaunchConfiguration("robot_name"),
+            "stand": LaunchConfiguration("stand")
+        }.items(),
+        condition=IfCondition(LaunchConfiguration("use_sim"))
     )
 
-    joint_state_broadcaster_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
-        parameters=[{"use_sim_time": True}]
+    controllers = IncludeLaunchDescription(
+        PathJoinSubstitution(
+            [
+                FindPackageShare("solo12_bringup"),
+                "launch",
+                "controllers.launch.py"
+            ]
+        ),
+        launch_arguments={
+            "use_sim_time": LaunchConfiguration("use_sim")
+        }.items()
     )
 
-    ros2_control_node = Node(
-        package="controller_manager",
-        executable="ros2_control_node",
-        parameters=[
-            robot_controllers
-        ],
-        output="both",
-        emulate_tty=True
+    rviz = IncludeLaunchDescription(
+        PathJoinSubstitution(
+            [
+                FindPackageShare("solo12_bringup"),
+                "launch",
+                "start_rviz.launch.py",
+            ]
+        ),
+        launch_arguments={
+            "rviz_config_file": LaunchConfiguration("rviz_config_file")
+        }.items(),
     )
 
+    return [
+        state_publisher,
+        sim_gazebo,
+        controllers,
+        rviz
+    ]
 
-    robot_state_pub_node = Node(
-        package="robot_state_publisher",
-        executable="robot_state_publisher",
-        output="both",
-        parameters=[
-            robot_description,
-            {"use_sim_time": True}
-        ],
-    )
+def generate_launch_description():
 
-    rviz_node = Node(
-        package="rviz2",
-        executable="rviz2",
-        name="rviz2",
-        output="log",
-        arguments=["-d", rviz_config_file],
-        condition=IfCondition(use_rviz)
-    )
+    ld = LaunchDescription()
 
-    # Delay rviz start after `joint_state_broadcaster`
-    delay_rviz = RegisterEventHandler(
-        event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[rviz_node],
-        )
-    )
+    ld.add_action(OpaqueFunction(function=launch_args))
 
+    ld.add_action(OpaqueFunction(function=launch_setup))
 
-    return LaunchDescription(
-        declared_arguments + 
-        [
-            gazebo,
-            robot_state_pub_node,
-            spawn_entity_node,
-            spawn_stand,
-            ros2_control_node,
-            joint_state_broadcaster_spawner,
-            delay_rviz
-        ]
-    )
+    return ld

--- a/solo12_bringup/launch/robot.launch.py
+++ b/solo12_bringup/launch/robot.launch.py
@@ -129,7 +129,8 @@ def generate_launch_description():
         parameters=[
             robot_controllers
         ],
-        output="both"
+        output="both",
+        emulate_tty=True
     )
 
 

--- a/solo12_bringup/launch/robot.launch.py
+++ b/solo12_bringup/launch/robot.launch.py
@@ -40,6 +40,14 @@ def generate_launch_description():
         ]
     )
 
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare("solo12_description"),
+            "config",
+            "solo12_controllers.yaml"
+        ]
+    )
+
     # Get URDF path
     urdf_path = os.path.join(
         get_package_share_directory("solo12_description"),
@@ -93,7 +101,7 @@ def generate_launch_description():
             ]
         ),
         launch_arguments={
-            "extra_gazebo_args": f"--ros-args --params-file {gazebo_configuration}"
+            # "extra_gazebo_args": f"--ros-args --params-file {gazebo_configuration.perform}" # Harley: fix path substitution
         }.items()
     )
 
@@ -113,6 +121,15 @@ def generate_launch_description():
         executable="spawner",
         arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
         parameters=[{"use_sim_time": True}]
+    )
+
+    ros2_control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[
+            robot_controllers
+        ],
+        output="both"
     )
 
 
@@ -151,6 +168,7 @@ def generate_launch_description():
             robot_state_pub_node,
             spawn_entity_node,
             spawn_stand,
+            ros2_control_node,
             joint_state_broadcaster_spawner,
             delay_rviz
         ]

--- a/solo12_bringup/launch/sim_gazebo.launch.py
+++ b/solo12_bringup/launch/sim_gazebo.launch.py
@@ -1,0 +1,132 @@
+from launch import LaunchDescription
+from launch.event_handlers import OnProcessExit
+from launch.conditions import IfCondition, UnlessCondition
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.actions import OpaqueFunction, DeclareLaunchArgument, IncludeLaunchDescription, RegisterEventHandler, ExecuteProcess
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.actions import Node
+
+def launch_args(context):
+    """
+    Launch arguments definition using an "opaque function"
+    to be able to later evaluate the launch argument at runtime.
+    """
+
+    declared_args = []
+
+    declared_args.append(
+        DeclareLaunchArgument(
+            "stand",
+            default_value="true",
+            description="Spawn stand for the robot."
+        )
+    )
+
+    declared_args.append(
+        DeclareLaunchArgument(
+            "robot_name",
+            default_value="solo12",
+            description="Robot name."
+        )
+    )
+
+    return declared_args
+
+def launch_setup(context):
+    """
+    Launch setup with access to `LaunchContext` to be able to read
+    launch arguments at runtime.
+    """
+
+    gazebo_configuration = PathJoinSubstitution(
+        [
+            FindPackageShare("solo12_description"),
+            "config",
+            "gazebo.yaml"
+        ]
+    )
+
+    launch_gazebo = IncludeLaunchDescription(
+        PathJoinSubstitution(
+            [
+                FindPackageShare("gazebo_ros"),
+                "launch",
+                "gazebo.launch.py"
+            ]
+        ),
+        launch_arguments={
+            "extra_gazebo_args": f"--ros-args --params-file {gazebo_configuration.perform(context)}"
+        }.items(),
+    )
+
+    spawn_stand = ExecuteProcess(
+        cmd=[
+            "xacro",
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("solo12_description"),
+                    "urdf",
+                    "stand.urdf"
+                ]
+            ),
+            "|",
+            "ros2", "run", "gazebo_ros", "spawn_entity.py", "-stdin", "-entity", "stand"
+        ],
+        output="both",
+        shell=True,
+        condition=IfCondition(LaunchConfiguration("stand"))
+    )
+
+    # subscribe to the `/robot_description` topic to wait for the robot definition.
+    # this node spawn the robot wen
+    # this node is launched only when the argument `stand` is false (just the robot in gazebo). 
+    only_spawn_solo_robot = Node(
+        package="gazebo_ros",
+        executable="spawn_entity.py",
+        name="spawn_entity",
+        arguments=['-topic', "robot_description",
+                   "-x", "0.0",
+                   "-y", "0.0",
+                   "-z", "0.54", 
+                   "-entity", "solo12"],
+        condition=UnlessCondition(LaunchConfiguration("stand"))
+    )
+
+
+    # If `stand`, launch this node. Used with `delay_spawn_solo_robot`
+    # Spawn the stand first and then the robot
+    spawn_solo_robot = Node(
+        package="gazebo_ros",
+        executable="spawn_entity.py",
+        name="spawn_entity",
+        arguments=['-topic', "robot_description",
+                   "-x", "0.0",
+                   "-y", "0.0",
+                   "-z", "0.54", 
+                   "-entity", LaunchConfiguration("robot_name")],
+    )
+
+    delay_spawn_solo_robot = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=spawn_stand,
+            on_exit=[spawn_solo_robot],
+        )
+    )
+
+    return [
+        launch_gazebo,
+        spawn_stand,
+        only_spawn_solo_robot,
+        delay_spawn_solo_robot
+    ]
+
+
+def generate_launch_description():
+
+    ld = LaunchDescription()
+
+    ld.add_action(OpaqueFunction(function=launch_args))
+
+    ld.add_action(OpaqueFunction(function=launch_setup))
+
+    return ld

--- a/solo12_bringup/launch/start_rviz.launch.py
+++ b/solo12_bringup/launch/start_rviz.launch.py
@@ -1,0 +1,40 @@
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction, DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+def launch_args(context):
+
+    declared_args = []
+
+    declared_args.append(
+        DeclareLaunchArgument(
+            "rviz_config_file"
+        )
+    )
+
+    return
+
+def launch_setup(context):
+
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="both",
+        arguments=["-d", LaunchConfiguration("rviz_config_file")],
+    )
+
+    return [
+        rviz_node
+    ]
+
+def generate_launch_description():
+
+    ld = LaunchDescription()
+
+    ld.add_action(OpaqueFunction(function=launch_args))
+
+    ld.add_action(OpaqueFunction(function=launch_setup))
+
+    return ld

--- a/solo12_bringup/launch/state_publisher.launch.py
+++ b/solo12_bringup/launch/state_publisher.launch.py
@@ -1,0 +1,58 @@
+import xacro
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction, DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+def launch_args(context):
+
+    declared_args = []
+
+    declared_args.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="true"
+        )
+    )
+
+    return declared_args
+
+def launch_setup(context):
+
+    robot_description_content = xacro.process_file(
+        PathJoinSubstitution(
+            [
+                FindPackageShare("solo12_description"),
+                "urdf",
+                "solo12.urdf.xacro"
+            ]
+        ).perform(context),
+        mappings={
+            "use_sim_time": LaunchConfiguration("use_sim_time").perform(context)
+        }
+    ).toxml()
+
+    robot_state_publiser_node = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="both",
+        parameters=[
+            {"robot_description": robot_description_content},
+            {"use_sim_time": LaunchConfiguration("use_sim_time")}
+        ]
+    )
+
+    return [
+        robot_state_publiser_node
+    ]
+
+def generate_launch_description():
+
+    ld = LaunchDescription()
+
+    ld.add_action(OpaqueFunction(function=launch_args))
+
+    ld.add_action(OpaqueFunction(function=launch_setup))
+
+    return ld

--- a/solo12_bringup/package.xml
+++ b/solo12_bringup/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>ros2_control</exec_depend>
+  <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
 

--- a/solo12_description/config/solo12_controllers.yaml
+++ b/solo12_description/config/solo12_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 30
+    update_rate: 500
     use_sim_time: true
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/solo12_description/launch/test_solo12_description.launch.py
+++ b/solo12_description/launch/test_solo12_description.launch.py
@@ -1,13 +1,30 @@
 import os
 import xacro
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory
+from launch.utilities import perform_substitutions
 
-def generate_launch_description():
+def launch_args(context):
+
+    declared_arguments = []
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim_time",
+            default_value="true",
+        )
+    )
+
+    return declared_arguments
+
+
+def launch_setup(context):
+
+    use_sim_time = LaunchConfiguration("use_sim_time")
 
     package_name = "solo12_description"
 
@@ -27,7 +44,7 @@ def generate_launch_description():
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="both",
-        parameters=[robot_description, {"use_sim_time": True}],
+        parameters=[robot_description, {"use_sim_time": use_sim_time}],
     )
 
     rviz_node = Node(
@@ -38,10 +55,18 @@ def generate_launch_description():
         arguments=["-d", rviz_config_file]
     )
 
-    return LaunchDescription(
-        [
+    return [
             joint_state_publisher_node,
             robot_state_publisher_node,
             rviz_node,
         ]
-    )
+
+def generate_launch_description():
+
+    ld = LaunchDescription()
+
+    ld.add_action(OpaqueFunction(function=launch_args))
+
+    ld.add_action(OpaqueFunction(function=launch_setup))
+
+    return ld

--- a/solo12_description/package.xml
+++ b/solo12_description/package.xml
@@ -16,7 +16,9 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>controller_manager</exec_depend> <!-- required for ros2_control-->
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/solo12_description/urdf/solo12.ros2_control.xacro
+++ b/solo12_description/urdf/solo12.ros2_control.xacro
@@ -1,76 +1,97 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <ros2_control name="GazeboSystem" type="system">
-    <hardware>
-      <plugin>gazebo_ros2_control/GazeboSystem</plugin>
-    </hardware>
-    <joint name="FL_HAA">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="FL_HFE">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="FL_KFE">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="FR_HAA">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="FR_HFE">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="FR_KFE">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="HL_HAA">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="HL_HFE">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="HL_KFE">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="HR_HAA">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="HR_HFE">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-    <joint name="HR_KFE">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-  </ros2_control>
+  <xacro:macro name="solo12_ros2_control" params="use_sim"> 
 
-  <gazebo>
-    <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
-      <parameters>$(find solo12_description)/config/solo12_controllers.yaml</parameters>
-    </plugin>
-  </gazebo>
+      <ros2_control name="Solo12HardwareInterface" type="system">
+        <hardware>
+
+          <!-- If "use_sim" argument is set to true launch gazebo simulation -->
+          <xacro:if value="${use_sim}">
+            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+          </xacro:if>
+
+          <!-- 
+            Otherwise launch real hardware
+
+          TODO:
+          - add hardware interface for the robot
+          -->
+          <xacro:unless value="${use_sim}">
+            <plugin>placeholder_namespace/PlaceHolderClass</plugin>
+          </xacro:unless>
+        </hardware>
+
+        <joint name="FL_HAA">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="FL_HFE">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="FL_KFE">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="FR_HAA">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="FR_HFE">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="FR_KFE">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="HL_HAA">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="HL_HFE">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="HL_KFE">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="HR_HAA">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="HR_HFE">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="HR_KFE">
+          <command_interface name="velocity"/>
+          <state_interface name="position"/>
+          <state_interface name="velocity"/>
+        </joint>
+      </ros2_control>
+
+    <xacro:if value="${use_sim}">
+      <gazebo>
+        <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
+          <parameters>$(find solo12_description)/config/solo12_controllers.yaml</parameters>
+        </plugin>
+      </gazebo>
+    </xacro:if>
+
+  </xacro:macro>
 
 </robot>

--- a/solo12_description/urdf/solo12.ros2_control.xacro
+++ b/solo12_description/urdf/solo12.ros2_control.xacro
@@ -6,50 +6,62 @@
       <plugin>gazebo_ros2_control/GazeboSystem</plugin>
     </hardware>
     <joint name="FL_HAA">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="FL_HFE">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="FL_KFE">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="FR_HAA">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="FR_HFE">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="FR_KFE">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="HL_HAA">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="HL_HFE">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="HL_KFE">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="HR_HAA">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="HR_HFE">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
     <joint name="HR_KFE">
+      <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>

--- a/solo12_description/urdf/solo12.urdf.xacro
+++ b/solo12_description/urdf/solo12.urdf.xacro
@@ -5,12 +5,17 @@
   xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
   xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
 
+  <xacro:arg name="use_sim" default="true" />
+
   <xacro:property name="color_name" value="grey" />
   <xacro:property name="color" value="0.8 0.8 0.8" />
   <xacro:property name="opacity" value="1.0" />
   <xacro:property name="mesh_ext" value="stl" />
 
   <xacro:include filename="solo12.ros2_control.xacro"/>
+
+  <xacro:solo12_ros2_control 
+    use_sim="$(arg use_sim)"/>
 
   <!-- This file is based on: https://github.com/open-dynamic-robot-initiative/open_robot_actuator_hardware/blob/master/mechanics/quadruped_robot_12dof_v1/README.md#quadruped-robot-12dof-v1 -->
   <link name="base_link">

--- a/solo12_examples/CMakeLists.txt
+++ b/solo12_examples/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.8)
+project(solo12_examples)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+add_executable(minimal src/minimal.cpp)
+# ament_target_dependencies(talker rclcpp std_msgs)
+
+install(TARGETS
+  minimal
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/solo12_examples/package.xml
+++ b/solo12_examples/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>solo12_examples</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="harley.lara@outlook.com">harley</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/solo12_examples/src/minimal.cpp
+++ b/solo12_examples/src/minimal.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main(int argc, char * argv[])
+{
+    std::cout << "test";
+    return 0;
+}


### PR DESCRIPTION
List of changes:
- [x] refactor of the launch system,
- [x] add xacro argument for handling hardware interface selection (sim or real) 
- [x] update documentation

## About the refactor:
The main idea behind the reactor is to keep a clean and modular code. The previous `robot.launch.py` was growing rapidly in complexity and getting difficult to follow and navigate, for that reason the launch system was breakdown into sub-components:
- `state_publisher.launch.py`
- `sim_gazebo.launch.py`
- `controller.launch.py`
- `start_rviz.launch.py`

In addition to the re-structuring the whole launch system was changed to use [`OpaqueFunctions`](https://github.com/ros2/launch/blob/rolling/launch/launch/actions/opaque_function.py), the idea behind them is to be able to evaluate `LaunchConfiguration` at runtime. Example:

For launch the robot description as `urdf` we use `xacro.process_file` from [ros xacro](https://github.com/ros/xacro), the main problem arises when you want to convert **launch arguments** to **xacro arguments**.

_side node related with `xacro.process_file`_, the key-word argument `mappings` is not document and required knowledge about the [source code](https://github.com/ros/xacro/blob/a74680211dc2b6bdbef9d4a153ace6616fcf61aa/src/xacro/__init__.py#L1102-L1124). 

## Bug Fixes

- Launch robot in stand prevents undesirables collisions: At the moment of launching the simulation with the stand and the robot, sometimes the robot appeared first and then the stand, this produced unwanted interbody collisions between the two objects, because when the robot was falling due to gravity it was intercepted by the sudden appearance of the stand, this caused the robot to shoot in random directions.